### PR TITLE
Prevent bots from submitting payments via reCaptcha

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,8 @@ CURRENCY_ACCOUNTS = {
     'GBP': os.environ.get('BT_MERCHANT_ACCOUNT_GBP'),
 }
 
+RECAPTCHA_SITE_KEY = os.environ.get('BT_RECAPTCHA_SITE_KEY') 
+
 @auth.verify_password
 def verify_password(username, password):
     return (username == os.environ.get('BT_AUTH_USER')) and \
@@ -73,13 +75,14 @@ def new_checkout_invoice(invoice, amount, currency):
         amount=amount / 100.0,
         currency=currency,
         currency_symbol=currency_symbol,
+        recaptcha_token=RECAPTCHA_SITE_KEY,
     )
 
 @app.route('/checkouts/new', methods=['GET'])
 @auth.login_required
 def new_checkout():
     client_token = generate_client_token()
-    return render_template('checkouts/new.html', client_token=client_token)
+    return render_template('checkouts/new.html', client_token=client_token, recaptcha_token=RECAPTCHA_SITE_KEY)
 
 @app.route('/checkouts/<transaction_id>', methods=['GET'])
 @auth.login_required

--- a/templates/checkouts/new.html
+++ b/templates/checkouts/new.html
@@ -33,14 +33,30 @@
       <input id="currency" name="currency" type="hidden" value="{{ currency }}">
       <input type="hidden" id="nonce" name="payment_method_nonce" />
       <button class="button" type="submit" id="submit-button"><span>Submit payment</span></button>
+      <div id="recaptcha" class="g-recaptcha" data-sitekey="{{ recaptcha_token }}" data-callback="onSubmit" data-size="invisible"></div>
     </form>
   </div>
 </div>
 
 <script src="https://js.braintreegateway.com/web/dropin/1.21.0/js/dropin.min.js"></script>
+<script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <script>
   var form = document.querySelector('#payment-form');
   var client_token = '{{ client_token }}';
+  var btInstance;
+
+  function onSubmit(token) {
+    btInstance.requestPaymentMethod(function (err, payload) {
+        if (err) {
+          console.log('Error', err);
+          return;
+        }
+
+        // Add the nonce to the form and submit
+        document.querySelector('#nonce').value = payload.nonce;
+        form.submit();
+      });
+  }
 
   braintree.dropin.create({
     authorization: client_token,
@@ -51,17 +67,8 @@
   }, function (createErr, instance) {
     form.addEventListener('submit', function (event) {
       event.preventDefault();
-
-      instance.requestPaymentMethod(function (err, payload) {
-        if (err) {
-          console.log('Error', err);
-          return;
-        }
-
-        // Add the nonce to the form and submit
-        document.querySelector('#nonce').value = payload.nonce;
-        form.submit();
-      });
+      btInstance = instance;
+      grecaptcha.execute();
     });
   });
 </script>


### PR DESCRIPTION
## Why

Prevent bots from submitting automated payments (ie: carding attacks)

## What
- [x] reCaptcha is used to validate the form submission